### PR TITLE
proxy for api calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<a name="1.4.6"></a>
+# [1.4.6](https://github.com/getbeyond/beyond-cli/compare/v1.4.5...v1.4.6) (2019-01-07)
+
+ ### Features
+* New command `proxy` which you can develop apps using the standard tool with, as shown [here](https://github.com/getbeyond/beyond-cli/pull/5#issuecomment-438664560)
+
 <a name="1.4.3"></a>
 # [1.4.3](https://github.com/getbeyond/beyond-cli/compare/v1.4.2...v1.4.3) (2018-10-19)
 

--- a/bin/beyond
+++ b/bin/beyond
@@ -31,6 +31,7 @@ versionCheckPromise
       .command('serve', 'Startup a session using the distributable files.')
       .command('test', 'Run unit tests.')
       .command('report', 'Run report in paql or js')
+      .command('proxy', 'Catch all requests')
       .parse(process.argv);
 
   })

--- a/bin/beyond-proxy
+++ b/bin/beyond-proxy
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+'use strict';
+
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+
+let _                          = require('lodash');
+let CLIConfig                  = require('../lib/config');
+let login                      = require('../lib/login');
+let program                    = require('commander');
+let Proxy                      = require('../lib/proxy');
+let setupConsoleLoggingHelpers = require('../lib/setup-console-logging-helpers');
+
+setupConsoleLoggingHelpers();
+
+program
+  .option('-c, --customer', 'Run against a customer account. Defaults to developer.')
+  .option('-a, --account [value]', 'Use the given account ID as the default account to load.')
+  .option('-k, --key [value]', 'Path to a secure file where credentials are stored in the format username:password.')
+  .option('-t, --token [value]', 'Impersonation token. This takes priority over -k|--key.')
+  .option('-p, --port [value]', 'Use the given port for the web server.')
+  .option('-o, --host [value]', 'Use the given host for the web server.')
+  .option('-s, --ssl', 'Runs server using https protocol.')
+  .option('-m, --vhost', 'If running in a virtual machine, use this flag to automatically listen on 0.0.0.0 instead of localhost by default.')
+  .option('-e, --env [value]', 'The API environment to use. Defaults to production. Options: dev, staging, prod')
+  .parse(process.argv);
+
+try {
+
+  let config = new CLIConfig(program);
+
+  login(config)
+    .then((loggedIn) => {
+
+      if (loggedIn) {
+        try {
+          let runnerProcess = new Proxy(config);
+          runnerProcess.start();
+        } catch (ex) {
+          return Promise.reject(ex);
+        }
+      }
+
+    });
+
+} catch (ex) {
+
+  console.error(ex.stack || ex);
+  return false;
+
+}

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -1,0 +1,75 @@
+'use strict';
+
+let BaseProcess    = require('./base-process');
+let express        = require('express');
+let fs             = require('fs');
+let http           = require('http');
+let https          = require('https');
+let path           = require('path');
+
+class Proxy extends BaseProcess {
+
+  constructor(config) {
+
+    super(config);
+
+    this.app = express();
+    this.accessToken = (!!this.config.tokens && !!this.config.tokens.access_token) ?
+      this.config.tokens.access_token :
+      '';
+    this.accountId = this.config.accountId || this.config.accounts[0].id;
+    this.ssl = this.config.ssl ? 
+      {
+        cert   : fs.readFileSync(path.join(__dirname, '/ssl/wild.cli.getbeyond.com.cert')),
+        key    : fs.readFileSync(path.join(__dirname, '/ssl/wild.cli.getbeyond.com.key')),
+      } :
+      null;
+
+  }
+
+  start() {
+
+    const proxy = require('http-proxy').createProxyServer();
+    const target = this.config.apiBaseUrl;
+    const ssl = this.ssl;
+
+    this.app.use((req, res) => {
+      proxy.web(req, res, {
+        ssl,
+        target,
+        secure: false
+      });
+    });
+
+    proxy.on('proxyReq', proxyReq => {
+      proxyReq.path = proxyReq.path.replace('null', this.accountId);
+      proxyReq.setHeader('Authorization', this.accessToken);
+    });
+
+    proxy.on('error', console.error);
+
+    if (!this.config.ssl) {
+
+      this.server = http.createServer(this.app).listen(this.config.port, this.config.host);
+
+    } else {
+
+      this.server = https.createServer(this.httpsOptions, this.app).listen(this.config.port, this.config.host);
+    
+    }
+
+    Proxy._onStartMessage(`Proxy Server: http${this.config.ssl ? 's': ''}://${this.config.requestedHost}:${this.config.port} (Environment: ${this.config.env})`);
+
+  }
+
+  static _onStartMessage(message = '') {
+
+    console.info('--------------------------------------------------------------------');
+    console.info(message);
+    console.info('--------------------------------------------------------------------');
+
+  }
+  
+}
+
+module.exports = Proxy;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getbeyond/beyond-cli",
-  "version": "1.4.3",
+  "version": "1.4.6",
   "description": "Command Line tool for Beyond Application Development",
   "main": "bin/beyond",
   "bin": {


### PR DESCRIPTION
The brand new command `proxy` was added. It can be called like others, for example:
```sh
beyond proxy -k .creds
```
With that, we can use standard `ng serve` and translate all API calls happening within beyond-js. At this moment however it's required to change requests on browser level. I do this by installing [the extension](http://www.requestly.in/) and adding one simple rule: `https://api.dev.peachworks.com → http://localhost:8080`.

Angular's proxy (`ng serve --proxy-config some-conf.json`) doesn't work for calls with an absolute url which are set that way in `beyond.session`. That's why I decided to use the extension instead of tweaking the code for dev environment.

What do you think, @guyjstitt, @mbebas, @darushka, @dadasign, @kacepe? 

Now, eventually, we can use a debugger or configure HMR and get rid of the iframe. Yay!

### todo
- [x] avoid using a browser extension
- [x] review command's options (fix ssl)
- [x] add menu somehow in dev mode